### PR TITLE
マークダウンフォームの非同期表示と非表示と見た目修正

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -265,10 +265,6 @@
   color: #333;
   text-decoration: none;
 
-  &:hover {
-    color: #FF914D;
-  }
-
   &.cover-image {
     display: none;
     color: #fff;
@@ -290,6 +286,10 @@
     transform: translate(-50%, -50%);
     white-space: nowrap;
   }
+
+  &:hover {
+    color: #FF914D;
+  }
 }
 
 .js-modal-close {
@@ -299,4 +299,33 @@
   color: #333;
   border: 1px solid #333;
   border-radius: 10px;
+}
+
+.markdown-form {
+  width: 100%;
+}
+
+.markdown-button {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+
+  &-cancel {
+    line-height: 36px;
+    padding: 0 30px;
+    color: #333;
+    background-color: #fff;
+    border: 1px solid #333;
+    border-radius: 10px;
+  }
+
+  &-update {
+    line-height: 36px;
+    padding: 0 30px;
+    color: #fff;
+    background-color: #FF914D;
+    border: 1px solid #333;
+    border-radius: 10px;
+    margin-left: 16px;
+  }
 }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,7 +16,11 @@ class ProfilesController < ApplicationController
     @user = User.find(current_user.id)
     @profile = @user.profile
     @basic = @user.basic
-    @profile.update(profile_params)
+    if @profile.update(profile_params)
+      redirect_to "/users/#{current_user.id}/profiles/edit", notice: 'プロフィールを更新しました'
+    else
+      render :edit
+    end
     # @basic.update(basic_params)
   end
 

--- a/app/javascript/jquery/src/jquery.js
+++ b/app/javascript/jquery/src/jquery.js
@@ -1,3 +1,4 @@
 import "./test";
 import "./profiles_modal";
 import "./profiles";
+import "./profiles_markdown";

--- a/app/javascript/jquery/src/profiles_markdown.js
+++ b/app/javascript/jquery/src/profiles_markdown.js
@@ -1,0 +1,25 @@
+$(function() {
+  $(document).on("click", '.js-edit-markdown-button', function() {
+    let markdownId = $(this).data('target');
+    let markdownLabelArea = $('#js-label-' + markdownId);
+    let markdownTextArea = $('#js-textarea-' + markdownId);
+    let markdownButton = $('#js-button-' + markdownId);
+
+    markdownLabelArea.hide();
+    markdownTextArea.show();
+    markdownButton.show();
+  })
+})
+
+$(function() {
+  $(document).on("click", '.markdown-cancel-button', function() {
+    let markdownId = $(this).data('cancel-id');
+    let markdownLabelArea = $('#js-label-' + markdownId);
+    let markdownTextArea = $('#js-textarea-' + markdownId);
+    let markdownButton = $('#js-button-' + markdownId);
+
+    markdownLabelArea.show();
+    markdownTextArea.hide();
+    markdownButton.hide();
+  })
+})

--- a/app/javascript/jquery/src/profiles_markdown.js
+++ b/app/javascript/jquery/src/profiles_markdown.js
@@ -12,7 +12,7 @@ $(function() {
 })
 
 $(function() {
-  $(document).on("click", '.markdown-cancel-button', function() {
+  $(document).on("click", '.markdown-button-cancel', function() {
     let markdownId = $(this).data('cancel-id');
     let markdownLabelArea = $('#js-label-' + markdownId);
     let markdownTextArea = $('#js-textarea-' + markdownId);

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -45,7 +45,7 @@
                 %h2.profile__column-main-item-title 紹介文
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    %span.js-edit-markdown-button{data: { target: "markdown01"}}
+                    %span.js-edit-markdown-button.link{data: { target: "markdown01"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
@@ -53,16 +53,16 @@
                 .profile__column-main-item-content#js-label-markdown01
                   = markdown(@profile.introduction)
                 = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                  = f.text_area :introduction, id: "js-textarea-markdown01", class: "form-control", style: "display: none"
-                  #js-button-markdown01{style: "display: none"}
-                    %button.markdown-cancel-button{data: {cancel: {id: "markdown01"}}} 閉じる
-                    = f.submit "更新する", data: {update: {id: "markdown01"}}
+                  = f.text_area :introduction, id: "js-textarea-markdown01", class: "markdown-form form-control", style: "display: none"
+                  .markdown-button#js-button-markdown01{style: "display: none"}
+                    %button.markdown-button-cancel{type: "button", data: {cancel: {id: "markdown01"}}} 閉じる
+                    = f.submit "更新する", data: {update_id: "markdown01", user_id: current_user.id}, class: "markdown-button-update"
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 目標
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    %span.js-edit-markdown-button{data: { target: "markdown02"}}
+                    %span.js-edit-markdown-button.link{data: { target: "markdown02"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
@@ -70,16 +70,16 @@
                 .profile__column-main-item-content#js-label-markdown02
                   = markdown(@profile.goal)
                 = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                  = f.text_area :goal, id: "js-textarea-markdown02", class: "form-control", style: "display: none"
-                  #js-button-markdown02{style: "display: none"}
-                    %button.markdown-cancel-button{data: {cancel: {id: "markdown02"}}} 閉じる
-                    = f.submit "更新する", data: {update: {id: "markdown02"}}
+                  = f.text_area :goal, id: "js-textarea-markdown02", class: "markdown-form form-control", style: "display: none"
+                  .markdown-button#js-button-markdown02{style: "display: none"}
+                    %button.markdown-button-cancel{type: "button", data: {cancel: {id: "markdown02"}}} 閉じる
+                    = f.submit "更新する", data: {update_id: "markdown02", user_id: current_user.id}, class: "markdown-button-update"
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 経歴
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    %span.js-edit-markdown-button{data: { target: "markdown03"}}
+                    %span.js-edit-markdown-button.link{data: { target: "markdown03"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
@@ -87,10 +87,10 @@
                 .profile__column-main-item-content#js-label-markdown03
                   = markdown(@profile.career)
                 = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                  = f.text_area :career, id: "js-textarea-markdown03", class: "form-control", style: "display: none"
-                  #js-button-markdown03{style: "display: none"}
-                    %button.markdown-cancel-button{data: {cancel: {id: "markdown03"}}} 閉じる
-                    = f.submit "更新する", data: {update: {id: "markdown03"}}
+                  = f.text_area :career, id: "js-textarea-markdown03", class: "markdown-form form-control", style: "display: none"
+                  .markdown-button#js-button-markdown03{style: "display: none"}
+                    %button.markdown-button-cancel{type: "button", data: {cancel: {id: "markdown03"}}} 閉じる
+                    = f.submit "更新する", data: {update_id: "markdown03", user_id: current_user.id}, class: "markdown-button-update"
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 関連リンク

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -45,43 +45,52 @@
                 %h2.profile__column-main-item-title 紹介文
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    = link_to "#" do
+                    %span.js-edit-markdown-button{data: { target: "markdown01"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
-              %p.profile__column-main-item-content
-                = markdown(@profile.introduction)
-              = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                = f.text_area :introduction
-                = f.submit "更新する"
+              #js-markdown01
+                .profile__column-main-item-content#js-label-markdown01
+                  = markdown(@profile.introduction)
+                = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
+                  = f.text_area :introduction, id: "js-textarea-markdown01", class: "form-control", style: "display: none"
+                  #js-button-markdown01{style: "display: none"}
+                    %button.markdown-cancel-button{data: {cancel: {id: "markdown01"}}} 閉じる
+                    = f.submit "更新する", data: {update: {id: "markdown01"}}
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 目標
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    = link_to "#" do
+                    %span.js-edit-markdown-button{data: { target: "markdown02"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
-              %p.profile__column-main-item-content
-                = markdown(@profile.goal)
-              = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                = f.text_area :goal
-                = f.submit "更新する"
+              #js-markdown02
+                .profile__column-main-item-content#js-label-markdown02
+                  = markdown(@profile.goal)
+                = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
+                  = f.text_area :goal, id: "js-textarea-markdown02", class: "form-control", style: "display: none"
+                  #js-button-markdown02{style: "display: none"}
+                    %button.markdown-cancel-button{data: {cancel: {id: "markdown02"}}} 閉じる
+                    = f.submit "更新する", data: {update: {id: "markdown02"}}
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 経歴
                 %ul.profile__column-main-item-icons
                   %li.profile__column-main-item-icons-item
-                    = link_to "#" do
+                    %span.js-edit-markdown-button{data: { target: "markdown03"}}
                       = icon("fas", "edit")
                   %li.profile__column-main-item-icons-item
                     公開
-              %p.profile__column-main-item-content
-                = markdown(@profile.career)
-              = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
-                = f.text_area :career
-                = f.submit "更新する"
+              #js-markdown03
+                .profile__column-main-item-content#js-label-markdown03
+                  = markdown(@profile.career)
+                = form_with model: @profile, url: {controller: 'profiles', action: 'show' }, local: true do |f|
+                  = f.text_area :career, id: "js-textarea-markdown03", class: "form-control", style: "display: none"
+                  #js-button-markdown03{style: "display: none"}
+                    %button.markdown-cancel-button{data: {cancel: {id: "markdown03"}}} 閉じる
+                    = f.submit "更新する", data: {update: {id: "markdown03"}}
             %section.profile__column-main-item
               .profile__column-main-item--top
                 %h2.profile__column-main-item-title 関連リンク


### PR DESCRIPTION
## What
マークダウンフォームの非同期表示と非表示を実装しました。
マークダウン形式でプロフィールを更新したときに、ページ更新をするようにしました。
マークダウンフォームの見た目を修正しました。

## Why
マークダウンフォームを非同期で表示・非表示することで、ユーザービリティが上がるため。