### PR TITLE
ユーザー新規登録のウィザードにプロフィール項目を実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,10 +30,24 @@ class Users::RegistrationsController < Devise::RegistrationsController
       render :new_basic and return
     end
     @user.build_basic(@basic.attributes)
-    @user.save
-    session["devise.regist_data"]["user"].clear
-    sign_in(:user, @user)
-    redirect_to root_path, notice: '新規登録しました'
+    session["basic"] = @basic.attributes
+    @profile = @user.build_profile
+    render :new_profile
+  end
+
+  def create_profile
+    @user = User.new(session["devise.regist_data"]["user"])
+    @basic = Basic.new(session["basic"])
+    @profile = Profile.new(profile_params)
+    @user.build_basic(@basic.attributes)
+    @user.build_profile(@profile.attributes)
+    if @user.save
+      session["devise.regist_data"]["user"].clear
+      sign_in(:user, @user)
+      redirect_to root_path, notice: '新規登録しました'
+    else
+      render :new_profile and return
+    end
   end
 
   # GET /resource/edit
@@ -64,6 +78,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def basic_params
     params.require(:basic).permit(:birth_place, :birth_date, :blood_type, :gender)
+  end
+
+  def profile_params
+    params.required(:profile).permit(:cover_image, :profile_image, :catch_copy, :introduction, :goal, :career, :related_title, :related_link, :attached_file)
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,7 +3,7 @@ class Profile < ApplicationRecord
   validates :introduction, length: { maximum: 3000 }
   validates :goal, length: { maximum: 300 }
   validates :career, length: { maximum: 2000 }
-  belongs_to :user
+  belongs_to :user, optional: true
 
   mount_uploader :cover_image, ImageUploader
   mount_uploader :profile_image, ImageUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,6 @@ class User < ApplicationRecord
   validates :username, presence: true, length: { maximum: 15 }, uniqueness: true, format: { with: /\A@[a-z0-9]+\z/ }
   validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/}
   validates :password, presence: true, format: { with: /\A[a-z0-9]+\z/i }
-  has_one :basic
+  has_one :basic, dependent: :destroy
   has_one :profile, dependent: :destroy
 end

--- a/app/views/devise/registrations/new_profile.html.haml
+++ b/app/views/devise/registrations/new_profile.html.haml
@@ -1,0 +1,20 @@
+.sign-up__wrapper
+  .sign-up__box
+    = image_tag "/assets/title-logo.png", alt: "新規登録ロゴ画像", height: "44px", class: "sign-up__box-logo"
+    %h2.sign-up__box-title 新規登録して続ける(任意項目)
+    = form_for @profile, html: {class: "sign-up__form"} do |f|
+      = render "devise/shared/error_messages", resource: @profile
+      .sign-up__form-item
+        = f.label :introduction, "紹介文"
+        %span.sign-up__form-optional 任意
+        %span.sign-up__form-confirm あとからでも編集ができます
+        %br/
+        = f.text_area :introduction, class: "sign-up__form-input", value: "こんにちは、○○です。よろしくお願いします。"
+      .sign-up__form-item
+        = f.label :career, "経歴"
+        %span.sign-up__form-optional 任意
+        %span.sign-up__form-confirm あとからでも編集ができます
+        %br/
+        = f.text_area :career, class: "sign-up__form-input", value: "○○年△△月□□日に、☆☆高校を卒業しました。"
+      .sign-up__form-submit
+        = f.submit "→", class: "sign-up__form-btn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     get 'basics', to: 'users/registrations#new_basic'
     post 'basics', to: 'users/registrations#create_basic'
+    get 'profiles', to: 'users/registrations#new_profile'
+    post 'profiles', to: 'users/registrations#create_profile'
   end
 
   resources :users do

--- a/db/migrate/20200904024940_create_profiles.rb
+++ b/db/migrate/20200904024940_create_profiles.rb
@@ -1,15 +1,15 @@
 class CreateProfiles < ActiveRecord::Migration[6.0]
   def change
     create_table :profiles do |t|
-      t.string :cover_image
-      t.string :profile_image
-      t.string :catch_copy
-      t.text :introduction 
-      t.string :goal
+      t.string :cover_image,    default: 'no-profile.png'
+      t.string :profile_image,  default: 'no-profile.png'
+      t.string :catch_copy,     default: 'キャッチコピーを更新してください'
+      t.text :introduction
+      t.string :goal,           default: '目標を更新してください'
       t.text :career
-      t.string :related_title
-      t.string :related_link
-      t.string :attached_file
+      t.string :related_title,  default: '関連タイトルを更新してください'
+      t.string :related_link,   default: '関連リンクを更新してください'
+      t.string :attached_file,  default: '添付ファイルを更新してください'
       t.references :user
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,15 +24,15 @@ ActiveRecord::Schema.define(version: 2020_09_04_024940) do
   end
 
   create_table "profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "cover_image"
-    t.string "profile_image"
-    t.string "catch_copy"
+    t.string "cover_image", default: "no-profile.png"
+    t.string "profile_image", default: "no-profile.png"
+    t.string "catch_copy", default: "キャッチコピーを更新してください"
     t.text "introduction"
-    t.string "goal"
+    t.string "goal", default: "目標を更新してください"
     t.text "career"
-    t.string "related_title"
-    t.string "related_link"
-    t.string "attached_file"
+    t.string "related_title", default: "関連タイトルを更新してください"
+    t.string "related_link", default: "関連リンクを更新してください"
+    t.string "attached_file", default: "添付ファイルを更新してください"
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## What
新規登録のウィザードにプロフィール項目を実装。
プロフィールの項目にデフォルト値を設定することで編集可能にした。

## Why
これまでの仕様だと、データベースに手打ちでデータを先に入れておかなければ、編集ページに移動できなかったため。